### PR TITLE
Skip captures on discarded cells

### DIFF
--- a/core/analytics_processor.py
+++ b/core/analytics_processor.py
@@ -41,7 +41,8 @@ class AnalyticsProcessor(QObject):
                     detections,
                     frame,
                     registrar_log_callback, # Use the provided callback
-                    cam_data
+                    cam_data,
+                    discarded_cells
                 )
                 # Emit a signal with some result if necessary
                 self.processing_finished.emit({"status": "success", "processed_alerts": gestor_alertas_instance.temporal})

--- a/gui/grilla_widget.py
+++ b/gui/grilla_widget.py
@@ -590,7 +590,12 @@ class GrillaWidget(QWidget):
                 self.registrar_log(f"Error cargando configuración: {e}")
         
         # MODIFICACIÓN: Inicializar GestorAlertas optimizado
-        self.alertas = GestorAlertas(cam_id=str(uuid.uuid4())[:8], filas=self.filas, columnas=self.columnas)
+        self.alertas = GestorAlertas(
+            cam_id=str(uuid.uuid4())[:8],
+            filas=self.filas,
+            columnas=self.columnas,
+            discarded_cells=self.discarded_cells,
+        )
         
         # Configurar el sistema optimizado de capturas
         if hasattr(self.alertas, 'configurar_capturas'):
@@ -759,10 +764,11 @@ class GrillaWidget(QWidget):
 
             # Procesar con el sistema optimizado
             self.alertas.procesar_detecciones(
-                detecciones_filtradas, 
+                detecciones_filtradas,
                 self.last_frame,
                 self.registrar_log,
-                self.cam_data
+                self.cam_data,
+                discarded_cells=self.discarded_cells
             )
             self.temporal = self.alertas.temporal
         


### PR DESCRIPTION
## Summary
- avoid saving images for detections that fall inside discarded cells
- pass discarded cell information to `GestorAlertas`
- update analytics processor and widget usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests, PyQt6; SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6878fc852ad8832dbbc3ef9265004006