### PR TITLE
Improve frame conversion via map()

### DIFF
--- a/gui/components.py
+++ b/gui/components.py
@@ -110,7 +110,29 @@ class MainGUI(QMainWindow):
         self.media_player.play()
 
     def manejar_frame_video(self, frame):
-        if frame.isValid():
+        if not frame.isValid():
+            return
+
+        image = None
+        if frame.map(QVideoFrame.MapMode.ReadOnly):
+            try:
+                pf = frame.pixelFormat()
+                img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
+                if img_format != QImage.Format.Format_Invalid:
+                    image = QImage(
+                        frame.bits(),
+                        frame.width(),
+                        frame.height(),
+                        frame.bytesPerLine(),
+                        img_format,
+                    ).copy()
+            finally:
+                frame.unmap()
+
+        if image is None:
             image = frame.toImage()
-            pixmap = QPixmap.fromImage(image)
-            self.video_widget1.setPixmap(pixmap)
+            if image.isNull():
+                return
+
+        pixmap = QPixmap.fromImage(image)
+        self.video_widget1.setPixmap(pixmap)

--- a/gui/grilla_widget.py
+++ b/gui/grilla_widget.py
@@ -837,57 +837,19 @@ class GrillaWidget(QWidget):
         if not should_process_ui:
             return
 
-        image = None
-        numpy_frame = None
-        img_converted = None
+        qimg = self._qimage_from_frame(frame)
+        if qimg is None:
+            return
 
-        if frame.map(QVideoFrame.MapMode.ReadOnly):
-            try:
-                pf = frame.pixelFormat()
-                rgb_formats = set()
-                for name in [
-                    "Format_RGB24", "Format_RGB32", "Format_BGR24", "Format_BGR32",
-                    "Format_RGBX8888", "Format_RGBA8888", "Format_BGRX8888", 
-                    "Format_BGRA8888", "Format_ARGB32",
-                ]:
-                    fmt = getattr(QVideoFrameFormat.PixelFormat, name, None)
-                    if fmt is not None:
-                        rgb_formats.add(fmt)
-
-                if pf in rgb_formats:
-                    img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
-                    if img_format != QImage.Format.Format_Invalid:
-                        qimg = QImage(
-                            frame.bits(),
-                            frame.width(),
-                            frame.height(),
-                            frame.bytesPerLine(),
-                            img_format,
-                        ).copy()
-                        image = qimg
-                        img_converted = qimg.convertToFormat(QImage.Format.Format_RGB888)
-                        ptr = img_converted.constBits()
-                        ptr.setsize(img_converted.width() * img_converted.height() * 3)
-                        numpy_frame = (
-                            np.frombuffer(ptr, dtype=np.uint8)
-                            .reshape((img_converted.height(), img_converted.width(), 3))
-                            .copy()
-                        )
-            finally:
-                frame.unmap()
-
-        if image is None:
-            image = frame.toImage()
-            if image.isNull():
-                return
-            img_converted = image.convertToFormat(QImage.Format.Format_RGB888)
-            ptr = img_converted.constBits()
-            ptr.setsize(img_converted.width() * img_converted.height() * 3)
-            numpy_frame = (
-                np.frombuffer(ptr, dtype=np.uint8)
-                .reshape((img_converted.height(), img_converted.width(), 3))
-                .copy()
-            )
+        img_converted = qimg.convertToFormat(QImage.Format.Format_RGB888)
+        ptr = img_converted.constBits()
+        ptr.setsize(img_converted.width() * img_converted.height() * 3)
+        numpy_frame = (
+            np.frombuffer(ptr, dtype=np.uint8)
+            .reshape((img_converted.height(), img_converted.width(), 3))
+            .copy()
+        )
+        image = qimg
 
         current_frame_width = img_converted.width()
         current_frame_height = img_converted.height()
@@ -916,6 +878,43 @@ class GrillaWidget(QWidget):
 
         self.pixmap = QPixmap.fromImage(img_converted)
         self.request_paint_update()
+
+    def _qimage_from_frame(self, frame: QVideoFrame) -> QImage | None:
+        """Convertir QVideoFrame a QImage usando map() si es posible"""
+        if not frame.map(QVideoFrame.MapMode.ReadOnly):
+            image = frame.toImage()
+            return image if not image.isNull() else None
+
+        try:
+            pf = frame.pixelFormat()
+            rgb_formats = {
+                getattr(QVideoFrameFormat.PixelFormat, name)
+                for name in [
+                    "Format_RGB24",
+                    "Format_RGB32",
+                    "Format_BGR24",
+                    "Format_BGR32",
+                    "Format_RGBX8888",
+                    "Format_RGBA8888",
+                    "Format_BGRX8888",
+                    "Format_BGRA8888",
+                    "Format_ARGB32",
+                ]
+                if hasattr(QVideoFrameFormat.PixelFormat, name)
+            }
+            if pf in rgb_formats:
+                img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
+                if img_format != QImage.Format.Format_Invalid:
+                    return QImage(
+                        frame.bits(),
+                        frame.width(),
+                        frame.height(),
+                        frame.bytesPerLine(),
+                        img_format,
+                    ).copy()
+            return None
+        finally:
+            frame.unmap()
 
     def registrar_log(self, mensaje):
         fecha_hora = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/gui/visualizador_detector.py
+++ b/gui/visualizador_detector.py
@@ -213,35 +213,37 @@ class VisualizadorDetector(QObject):
                 logger.error("%s: error procesando frame en on_frame: %s", self.objectName(), e)
 
     def _qimage_from_frame(self, frame: QVideoFrame) -> QImage | None:
-        if frame.map(QVideoFrame.MapMode.ReadOnly):
-            try:
-                pf = frame.pixelFormat()
-                rgb_formats = {
-                    getattr(QVideoFrameFormat.PixelFormat, name)
-                    for name in [
-                        "Format_RGB24",
-                        "Format_RGB32",
-                        "Format_BGR24",
-                        "Format_BGR32",
-                        "Format_RGBX8888",
-                        "Format_RGBA8888",
-                        "Format_BGRX8888",
-                        "Format_BGRA8888",
-                        "Format_ARGB32",
-                    ]
-                    if hasattr(QVideoFrameFormat.PixelFormat, name)
-                }
-                if pf in rgb_formats:
-                    img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
-                    if img_format != QImage.Format.Format_Invalid:
-                        return QImage(
-                            frame.bits(),
-                            frame.width(),
-                            frame.height(),
-                            frame.bytesPerLine(),
-                            img_format,
-                        ).copy()
-            finally:
-                frame.unmap()
-        image = frame.toImage()
-        return image if not image.isNull() else None
+        if not frame.map(QVideoFrame.MapMode.ReadOnly):
+            image = frame.toImage()
+            return image if not image.isNull() else None
+
+        try:
+            pf = frame.pixelFormat()
+            rgb_formats = {
+                getattr(QVideoFrameFormat.PixelFormat, name)
+                for name in [
+                    "Format_RGB24",
+                    "Format_RGB32",
+                    "Format_BGR24",
+                    "Format_BGR32",
+                    "Format_RGBX8888",
+                    "Format_RGBA8888",
+                    "Format_BGRX8888",
+                    "Format_BGRA8888",
+                    "Format_ARGB32",
+                ]
+                if hasattr(QVideoFrameFormat.PixelFormat, name)
+            }
+            if pf in rgb_formats:
+                img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
+                if img_format != QImage.Format.Format_Invalid:
+                    return QImage(
+                        frame.bits(),
+                        frame.width(),
+                        frame.height(),
+                        frame.bytesPerLine(),
+                        img_format,
+                    ).copy()
+            return None
+        finally:
+            frame.unmap()

--- a/ui/camara_secundaria.py
+++ b/ui/camara_secundaria.py
@@ -92,35 +92,37 @@ class CamaraSecundariaWorker(QThread):
         self.frame_ready.emit(arr)
 
     def _qimage_from_frame(self, frame: QVideoFrame) -> QImage | None:
-        if frame.map(QVideoFrame.MapMode.ReadOnly):
-            try:
-                pf = frame.pixelFormat()
-                rgb_formats = {
-                    getattr(QVideoFrameFormat.PixelFormat, name)
-                    for name in [
-                        "Format_RGB24",
-                        "Format_RGB32",
-                        "Format_BGR24",
-                        "Format_BGR32",
-                        "Format_RGBX8888",
-                        "Format_RGBA8888",
-                        "Format_BGRX8888",
-                        "Format_BGRA8888",
-                        "Format_ARGB32",
-                    ]
-                    if hasattr(QVideoFrameFormat.PixelFormat, name)
-                }
-                if pf in rgb_formats:
-                    img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
-                    if img_format != QImage.Format.Format_Invalid:
-                        return QImage(
-                            frame.bits(),
-                            frame.width(),
-                            frame.height(),
-                            frame.bytesPerLine(),
-                            img_format,
-                        ).copy()
-            finally:
-                frame.unmap()
-        image = frame.toImage()
-        return image if not image.isNull() else None
+        if not frame.map(QVideoFrame.MapMode.ReadOnly):
+            image = frame.toImage()
+            return image if not image.isNull() else None
+
+        try:
+            pf = frame.pixelFormat()
+            rgb_formats = {
+                getattr(QVideoFrameFormat.PixelFormat, name)
+                for name in [
+                    "Format_RGB24",
+                    "Format_RGB32",
+                    "Format_BGR24",
+                    "Format_BGR32",
+                    "Format_RGBX8888",
+                    "Format_RGBA8888",
+                    "Format_BGRX8888",
+                    "Format_BGRA8888",
+                    "Format_ARGB32",
+                ]
+                if hasattr(QVideoFrameFormat.PixelFormat, name)
+            }
+            if pf in rgb_formats:
+                img_format = QVideoFrameFormat.imageFormatFromPixelFormat(pf)
+                if img_format != QImage.Format.Format_Invalid:
+                    return QImage(
+                        frame.bits(),
+                        frame.width(),
+                        frame.height(),
+                        frame.bytesPerLine(),
+                        img_format,
+                    ).copy()
+            return None
+        finally:
+            frame.unmap()


### PR DESCRIPTION
## Summary
- use mapped QVideoFrame data in `_qimage_from_frame`
- display video frames using mapped image data
- add helper for mapping frames in `GrillaWidget`

## Testing
- `python -m py_compile gui/visualizador_detector.py ui/camara_secundaria.py gui/components.py gui/grilla_widget.py`
- `pytest -q` *(fails: ModuleNotFoundError for requests and PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68790fa90c94832d9c955a068859b9b3